### PR TITLE
TAVA-75-hotfix-env-keys-prod-mode

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -10,11 +10,14 @@ client-cert.key
 desktop.ini
 
 # secrets
+encode-script_env_keys.js
 set-env.dev.ts
 /src/environments/.env
 .env
 public_key.pem
+prod_public_key.pem
 private_key.pem
+prod_private_key.pem
 
 # public/images
 /public/assets/service/service-airport_big.jpg

--- a/frontend/set-env.ts
+++ b/frontend/set-env.ts
@@ -1,6 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const fs = require('fs');
 const targetPath = "./src/environments/environment.prod.ts";
+const public_key = process.env['PUBLIC_KEY'];
+const private_key = process.env['PRIVATE_KEY'];
+
+const modifiedPublicKey = String(public_key).replaceAll(/_/g, '\n').trim();
+const modifiedPrivateKey = String(private_key).replaceAll(/_/g, '\n').trim();
+
 const envConfigFile = `import { Environment } from "./environment.model";
 
 export const environment: Environment = {
@@ -10,8 +16,8 @@ export const environment: Environment = {
     MAIL_SUBJECT: '${process.env['MAIL_SUBJECT']}',
     AUTH_USER: '${process.env['AUTH_USER']}',
     AUTH_PASSWORD: '${process.env['AUTH_PASS']}',
-    PUBLIC_KEY: '${process.env['PUBLIC_KEY']}',
-    PRIVATE_KEY '${process.env['PRIVATE_KEY']}'
+    PUBLIC_KEY: \`${modifiedPublicKey}\`,
+    PRIVATE_KEY \`${modifiedPrivateKey}\`
 };
 `;
 fs.writeFileSync(targetPath, envConfigFile);


### PR DESCRIPTION
Adapt set-env.ts to convert env keys single-line to multi-line strings.
>> Netlify can't handle multi-line private/public keys as env vars