### PR TITLE
TAVA-75-hotfix-allowing-depency-commonjs-forge-node

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -17,6 +17,9 @@
         "build": {
           "builder": "@angular-devkit/build-angular:application",
           "options": {
+            "allowedCommonJsDependencies": [
+              "node-forge"
+            ],
             "outputPath": "dist/taxi-varga",
             "index": "src/index.html",
             "browser": "src/main.ts",


### PR DESCRIPTION
Optimization in prod mode can result in warnings by CommonJS import.
>> allowing dependencies in angular.json necessary