### PR TITLE
TAVA-133-refactor-fn-params

### DIFF
--- a/backend/src/models/driving/destination.driving.model.js
+++ b/backend/src/models/driving/destination.driving.model.js
@@ -145,11 +145,11 @@ class DrivingDestinationModel {
         const isOriginLA = Utils.checkAddressInLowerAustriaByProvince(originDetails.province ?? null);
         const isDestinationVIA = Utils.checkAddressAtViennaAirport(destinationDetails.zipCode ?? null);
         if(servDist <= 40) {
-            const isTimeWithinRange = Utils.isTimeStartingWithinRange(pickUp, '04:00', '10:00');
+            const isTimeWithinRange = Utils.isTimeStartingWithinRange(pickUp, '04:00', '09:59');
             return isTimeWithinRange && isOriginLA && isDestinationVIA ? this.#prices.discountLA2VIA : 0;
         }
         if(servDist > 40 && servDist <= 55) {
-            const isTimeWithinRange = Utils.isTimeStartingWithinRange(pickUp, '04:00', '06:00');
+            const isTimeWithinRange = Utils.isTimeStartingWithinRange(pickUp, '04:00', '05:59');
             return isTimeWithinRange && isOriginLA && isDestinationVIA ? this.#prices.discountLA2VIA : 0;
         }
         return 0;

--- a/backend/tests/unit-tests/models/driving/destination.models.test.js
+++ b/backend/tests/unit-tests/models/driving/destination.models.test.js
@@ -601,12 +601,12 @@ describe('Destination tests, priority: _calcDiscountLaToVIA', () => {
             expect(testFn).toBe(expectResult);
         })
 
-        test('Route (2525to1300), params <servDist> > 40 < 55, <pickUp> == "06:00"', () => {
+        test('Route (2525to1300), params <servDist> > 40 < 55, <pickUp> == "05:00"', () => {
             const mockData = structuredClone(MockData_RouteMatrix['route2525-1300']);
             const mockParam_originDetails = mockData['originDetails'];
             const mockParam_destinationDetails = mockData['destinationDetails'];
             const mockParam_servDist = mockData['a_information']['servDist'];
-            const mockParam_pickUp = '06:00';
+            const mockParam_pickUp = '05:00';
 
             const testFn = destinationModel._calcDiscountLaToVIA(
                 mockParam_originDetails, mockParam_destinationDetails, mockParam_servDist, mockParam_pickUp


### PR DESCRIPTION
Update wrongely set fn params on isTimeStartingWithinRange()
>> from '06:00' to '05:59' (frontend delivers whole hours only)